### PR TITLE
Cover all assert.fail() variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tapsert [![Build Status](https://travis-ci.org/tapjs/tapsert.svg)](https://travis-ci.org/tapjs/tapsert)
 =======
 
-An almost-drop-in replacement for the assert module provided by Node core that
+A total drop-in replacement for the assert module provided by Node core that
 prints TAP compliant output instead of throwing `AssertionError`s.
 
 Uses

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function tapifyAssert(assert) {
       console.log('ok %d - %s', n, desc);
     } catch (e) {
       failures += 1;
+      desc = (assert.name === 'fail') ? e.message :  desc;
       console.log('not ok %d - %s', n, desc);
       console.log(formatAssertionError(e));
     }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function tapifyAssert(assert) {
       console.log('ok %d - %s', n, desc);
     } catch (e) {
       failures += 1;
-      desc = (assert.name === 'fail') ? e.message :  desc;
+      desc = (assert.name === 'fail' && arguments.length) ? e.message :  desc;
       console.log('not ok %d - %s', n, desc);
       console.log(formatAssertionError(e));
     }

--- a/test/assert.fail.js
+++ b/test/assert.fail.js
@@ -17,7 +17,7 @@ assert.fail(actual, expected, undefined, operator);
   assert.fail(actual, expected, undefined, operator, stackStart);
 })();
 
-if (process.version >= 'v8.0.0') {
+if (!/^v[0-7]\./.test(process.version)) { // New API from node v8.0.0+
   assert.fail('with message only');
   assert.fail(actual, expected);
 }

--- a/test/assert.fail.js
+++ b/test/assert.fail.js
@@ -1,3 +1,19 @@
 const assert = require('../');
 
-assert.fail('actual', 'expected', 'Should never pass', 'assert.fail');
+const actual = 'actual';
+const expected = 'expected';
+const operator = '<=>';
+
+assert.fail('with message only');
+assert.fail(actual, expected);
+assert.fail(actual, expected, 'with custom message');
+assert.fail(actual, expected, 'with message and operator', operator);
+assert.fail(actual, expected, undefined, operator);
+
+(function stackStart() {
+  assert.fail(actual, expected, 'with everything', operator, stackStart);
+})();
+
+(function stackStart() {
+  assert.fail(actual, expected, undefined, operator, stackStart);
+})();

--- a/test/assert.fail.js
+++ b/test/assert.fail.js
@@ -4,6 +4,7 @@ const actual = 'actual';
 const expected = 'expected';
 const operator = '<=>';
 
+assert.fail();
 assert.fail(actual, expected, 'with custom message');
 assert.fail(actual, expected, 'with message and operator', operator);
 assert.fail(actual, expected, undefined, operator);

--- a/test/assert.fail.js
+++ b/test/assert.fail.js
@@ -4,8 +4,6 @@ const actual = 'actual';
 const expected = 'expected';
 const operator = '<=>';
 
-assert.fail('with message only');
-assert.fail(actual, expected);
 assert.fail(actual, expected, 'with custom message');
 assert.fail(actual, expected, 'with message and operator', operator);
 assert.fail(actual, expected, undefined, operator);
@@ -17,3 +15,8 @@ assert.fail(actual, expected, undefined, operator);
 (function stackStart() {
   assert.fail(actual, expected, undefined, operator, stackStart);
 })();
+
+if (process.version >= 'v8.0.0') {
+  assert.fail('with message only');
+  assert.fail(actual, expected);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -85,20 +85,27 @@ function assertFail(err, stdout, stderr) {
   assertHeader(err, stdout, stderr);
   assert(err, 'failing file exits with an error');
   assert.equal(stderr, '', 'assert.fail does not write to stderr');
-  assert(/^not ok 1 - with message only$/m.test(stdout),
-    'handles single-argument variant');
-  assert(/^not ok 2 - 'actual' != 'expected'$/m.test(stdout),
-    'handles two-argument variant');
-  assert(/^not ok 3 - with custom message$/m.test(stdout),
+
+  assert(/^not ok 1 - with custom message$/m.test(stdout),
     'handles three-argument variant');
-  assert(/^not ok 4 - with message and operator$/m.test(stdout),
+  assert(/^not ok 2 - with message and operator$/m.test(stdout),
     'handles four-argument variant');
-  assert(/^not ok 5 - 'actual' <=> 'expected'$/m.test(stdout),
+  assert(/^not ok 3 - 'actual' <=> 'expected'$/m.test(stdout),
     'handles four-argument variant with auto-message');
-    assert(/^not ok 6 - with everything$/m.test(stdout),
+  assert(/^not ok 4 - with everything$/m.test(stdout),
     'handles five-argument variant');
-  assert(/^not ok 7 - 'actual' <=> 'expected'$/m.test(stdout),
+  assert(/^not ok 5 - 'actual' <=> 'expected'$/m.test(stdout),
     'handles five-argument variant with auto-message');
-  assert(/^# tests 7$/m.test(stdout), 'assert.fail has 7 tests');
-  assert(/^# fail  7$/m.test(stdout), 'assert.fail has 7 failing tests');
+
+  if (process.version >= 'v8.0.0') {
+    assert(/^not ok 6 - with message only$/m.test(stdout),
+      'handles single-argument variant');
+    assert(/^not ok 7 - 'actual' != 'expected'$/m.test(stdout),
+      'handles two-argument variant');
+    assert(/^# tests 7$/m.test(stdout), 'assert.fail has 7 tests');
+    assert(/^# fail  7$/m.test(stdout), 'assert.fail has 7 failing tests');
+  } else {
+    assert(/^# tests 5$/m.test(stdout), 'assert.fail has 5 tests');
+    assert(/^# fail  5$/m.test(stdout), 'assert.fail has 5 failing tests');
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -86,26 +86,28 @@ function assertFail(err, stdout, stderr) {
   assert(err, 'failing file exits with an error');
   assert.equal(stderr, '', 'assert.fail does not write to stderr');
 
-  assert(/^not ok 1 - with custom message$/m.test(stdout),
+  assert(/^not ok 1 - fail$/m.test(stdout),
+    'handles no-args variant');
+  assert(/^not ok 2 - with custom message$/m.test(stdout),
     'handles three-argument variant');
-  assert(/^not ok 2 - with message and operator$/m.test(stdout),
+  assert(/^not ok 3 - with message and operator$/m.test(stdout),
     'handles four-argument variant');
-  assert(/^not ok 3 - 'actual' <=> 'expected'$/m.test(stdout),
+  assert(/^not ok 4 - 'actual' <=> 'expected'$/m.test(stdout),
     'handles four-argument variant with auto-message');
-  assert(/^not ok 4 - with everything$/m.test(stdout),
+  assert(/^not ok 5 - with everything$/m.test(stdout),
     'handles five-argument variant');
-  assert(/^not ok 5 - 'actual' <=> 'expected'$/m.test(stdout),
+  assert(/^not ok 6 - 'actual' <=> 'expected'$/m.test(stdout),
     'handles five-argument variant with auto-message');
 
   if (process.version >= 'v8.0.0') {
-    assert(/^not ok 6 - with message only$/m.test(stdout),
+    assert(/^not ok 7 - with message only$/m.test(stdout),
       'handles single-argument variant');
-    assert(/^not ok 7 - 'actual' != 'expected'$/m.test(stdout),
+    assert(/^not ok 8 - 'actual' != 'expected'$/m.test(stdout),
       'handles two-argument variant');
-    assert(/^# tests 7$/m.test(stdout), 'assert.fail has 7 tests');
-    assert(/^# fail  7$/m.test(stdout), 'assert.fail has 7 failing tests');
+    assert(/^# tests 8$/m.test(stdout), 'assert.fail has 8 tests');
+    assert(/^# fail  8$/m.test(stdout), 'assert.fail has 8 failing tests');
   } else {
-    assert(/^# tests 5$/m.test(stdout), 'assert.fail has 5 tests');
-    assert(/^# fail  5$/m.test(stdout), 'assert.fail has 5 failing tests');
+    assert(/^# tests 6$/m.test(stdout), 'assert.fail has 6 tests');
+    assert(/^# fail  6$/m.test(stdout), 'assert.fail has 6 failing tests');
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -85,10 +85,20 @@ function assertFail(err, stdout, stderr) {
   assertHeader(err, stdout, stderr);
   assert(err, 'failing file exits with an error');
   assert.equal(stderr, '', 'assert.fail does not write to stderr');
-  assert(/actual: "actual"$/m.test(stdout), 'includes "actual" value');
-  assert(/expected: "expected"$/m.test(stdout), 'includes "expected" value');
-  assert(/operator: "assert.fail"$/m.test(stdout), 'includes "operator"');
-  assert(/message: Should never pass/.test(stdout), 'includes "message"');
-  assert(/^# tests 1$/m.test(stdout), 'assert.fail has 1 tests');
-  assert(/^# fail  1$/m.test(stdout), 'assert.fail has 1 failing test');
+  assert(/^not ok 1 - with message only$/m.test(stdout),
+    'handles single-argument variant');
+  assert(/^not ok 2 - 'actual' != 'expected'$/m.test(stdout),
+    'handles two-argument variant');
+  assert(/^not ok 3 - with custom message$/m.test(stdout),
+    'handles three-argument variant');
+  assert(/^not ok 4 - with message and operator$/m.test(stdout),
+    'handles four-argument variant');
+  assert(/^not ok 5 - 'actual' <=> 'expected'$/m.test(stdout),
+    'handles four-argument variant with auto-message');
+    assert(/^not ok 6 - with everything$/m.test(stdout),
+    'handles five-argument variant');
+  assert(/^not ok 7 - 'actual' <=> 'expected'$/m.test(stdout),
+    'handles five-argument variant with auto-message');
+  assert(/^# tests 7$/m.test(stdout), 'assert.fail has 7 tests');
+  assert(/^# fail  7$/m.test(stdout), 'assert.fail has 7 failing tests');
 }

--- a/test/index.js
+++ b/test/index.js
@@ -99,7 +99,7 @@ function assertFail(err, stdout, stderr) {
   assert(/^not ok 6 - 'actual' <=> 'expected'$/m.test(stdout),
     'handles five-argument variant with auto-message');
 
-  if (process.version >= 'v8.0.0') {
+  if (!/^v[0-7]\./.test(process.version)) { // New API from node v8.0.0+
     assert(/^not ok 7 - with message only$/m.test(stdout),
       'handles single-argument variant');
     assert(/^not ok 8 - 'actual' != 'expected'$/m.test(stdout),


### PR DESCRIPTION
@rmg this continues what you started over in #2

What I had meant over in #1 (about `assert.fail`) is that it has many variants depending on which arguments are given.